### PR TITLE
Add healthchecks for MoFo services + alerts on AWS

### DIFF
--- a/aws/mofo-projects/health-checks/README.md
+++ b/aws/mofo-projects/health-checks/README.md
@@ -1,2 +1,19 @@
 # Health-checks
 
+Dashboard: https://console.aws.amazon.com/route53/healthchecks/home#/ (mofo-project)
+
+## Services monitored
+
+- foundation site
+- pulse (front + api)
+- donate (mofo + thunderbird)
+- Internet-health-report (email only)
+
+Send an alert after 30min of downtime.
+
+## How to add a new service
+
+- Paging alert: add the name and url of that service to the `high-priority-services` variable.
+- email only: add the name and url of that service to the `low-priority-services` variable.
+
+Once it's done, apply the new plan.

--- a/aws/mofo-projects/health-checks/README.md
+++ b/aws/mofo-projects/health-checks/README.md
@@ -1,0 +1,2 @@
+# Health-checks
+

--- a/aws/mofo-projects/health-checks/health-checks.tf
+++ b/aws/mofo-projects/health-checks/health-checks.tf
@@ -1,0 +1,50 @@
+# Paging alerts are sent to victorops
+data "aws_sns_topic" "victorops-integration" {
+  name = "VictorOps"
+}
+
+# Non-paging alerts are sent to the mofo devops mailing list
+data "aws_sns_topic" "mofo-devops-email" {
+  name = "devops_mofo"
+}
+
+# CloudWatch's alerts
+resource "aws_cloudwatch_metric_alarm" "health-checks-victorops-alerts" {
+  for_each = var.high-priority-services
+
+  alarm_name          = "${each.key}-health-check-failed"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "6"
+  datapoints_to_alarm = "6"
+  period              = "300"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "last 3 health-checks failed for ${each.key} (30 minutes downtime)"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.health-checks[each.key].id
+  }
+
+  alarm_actions = [data.aws_sns_topic.victorops-integration.arn]
+
+  tags = local.tags
+}
+
+# Services' health-checks
+resource "aws_route53_health_check" "health-checks" {
+  for_each = var.high-priority-services
+
+  fqdn              = each.value
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "10"
+  request_interval  = "30"
+  regions           = ["eu-west-1", "us-east-1", "us-west-1"]
+  measure_latency   = true
+
+  tags = local.tags
+}
+

--- a/aws/mofo-projects/health-checks/health-checks.tf
+++ b/aws/mofo-projects/health-checks/health-checks.tf
@@ -8,7 +8,7 @@ data "aws_sns_topic" "mofo-devops-email" {
   name = "devops_mofo"
 }
 
-# CloudWatch's alerts
+# High priority services' CloudWatch alerts
 resource "aws_cloudwatch_metric_alarm" "health-checks-victorops-alerts" {
   for_each = var.high-priority-services
 
@@ -32,9 +32,49 @@ resource "aws_cloudwatch_metric_alarm" "health-checks-victorops-alerts" {
   tags = local.tags
 }
 
-# Services' health-checks
+# High priority services' health-checks
 resource "aws_route53_health_check" "health-checks" {
   for_each = var.high-priority-services
+
+  fqdn              = each.value
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  failure_threshold = "10"
+  request_interval  = "30"
+  regions           = ["eu-west-1", "us-east-1", "us-west-1"]
+  measure_latency   = true
+
+  tags = local.tags
+}
+
+# Low priority services' CloudWatch alerts
+resource "aws_cloudwatch_metric_alarm" "health-checks-victorops-alerts-low-priority" {
+  for_each = var.low-priority-services
+
+  alarm_name          = "${each.key}-health-check-failed"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "6"
+  datapoints_to_alarm = "6"
+  period              = "300"
+  statistic           = "Minimum"
+  threshold           = "1"
+  alarm_description   = "last 3 health-checks failed for ${each.key} (30 minutes downtime)"
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.health-checks-low-priority[each.key].id
+  }
+
+  alarm_actions = [data.aws_sns_topic.mofo-devops-email.arn]
+
+  tags = local.tags
+}
+
+# Low priority services' health-checks
+resource "aws_route53_health_check" "health-checks-low-priority" {
+  for_each = var.low-priority-services
 
   fqdn              = each.value
   port              = 443

--- a/aws/mofo-projects/health-checks/main.tf
+++ b/aws/mofo-projects/health-checks/main.tf
@@ -1,0 +1,38 @@
+# Configure the AWS Provider
+provider "aws" {
+  version             = "~> 2.0"
+  region              = "us-east-1"
+  allowed_account_ids = var.allowed_account_ids
+  profile             = "mofo-projects-MoFoProjectsAdmin"
+}
+
+module "terraform-backend" {
+  source = "github.com/mozilla-it/terraform-modules//aws/s3-backend"
+
+  # Set variables
+  backend_bucket         = "terraform-backend-health-checks"
+  backend_key            = "terraform.tfstate"
+  backend_dynamodb_table = "terraform-backend-health-checks"
+  read_capacity          = 5
+  write_capacity         = 5
+  region                 = "us-east-1"
+  tags                   = local.tags
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "terraform-backend-health-checks"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+    profile        = "mofo-projects-MoFoProjectsAdmin"
+    dynamodb_table = "terraform-backend-health-checks"
+  }
+}
+
+
+locals {
+  tags = {
+    project     = "health-checks",
+    description = "Managed by Terraform"
+  }
+}

--- a/aws/mofo-projects/health-checks/variables.tf
+++ b/aws/mofo-projects/health-checks/variables.tf
@@ -1,0 +1,24 @@
+# S3 backend variables
+variable "allowed_account_ids" {
+  description = "List of allowed AWS account ids where resources can be created"
+  type        = list
+  default     = []
+}
+
+variable "high-priority-services" {
+  description = "Services in that list will page if down"
+  type        = map
+  default = {
+    "foundation-site"    = "foundation.mozilla.org",
+    "donate-mofo"        = "donate.mozilla.org",
+    "donate-thunderbird" = "give.thunderbird.net"
+    "network-pulse"      = "www.mozillapulse.org",
+    "network-pulse-api"  = "api.mozillapulse.org"
+  }
+}
+
+//variable "low-priority-services" {
+//  description = "Services in that list will send an email if down"
+//  type        = list
+//  default     = []
+//}

--- a/aws/mofo-projects/health-checks/variables.tf
+++ b/aws/mofo-projects/health-checks/variables.tf
@@ -17,8 +17,10 @@ variable "high-priority-services" {
   }
 }
 
-//variable "low-priority-services" {
-//  description = "Services in that list will send an email if down"
-//  type        = list
-//  default     = []
-//}
+variable "low-priority-services" {
+  description = "Services in that list will send an email if down"
+  type        = map
+  default = {
+    "Internet-health-report" = "internethealthreport.org"
+  }
+}


### PR DESCRIPTION
Replace pingdom by alerts on AWS. It's cheaper (17$/month instead of 90$/month) and easier to customize.
First part is done: it's monitoring and alerting for our major services. Second part coming when I'm done with today's meetings.
Route53 dashboard: https://console.aws.amazon.com/route53/healthchecks/home#/ (mofo-projects)